### PR TITLE
Change operator framework imports to 'import ops' style

### DIFF
--- a/action-charm/src/charm.py
+++ b/action-charm/src/charm.py
@@ -13,14 +13,12 @@ The Action Charm
 from cmath import e
 import logging
 
-from ops.charm import CharmBase
-from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
+import ops
 
 # Log messages can be retrieved using juju debug-log
 logger = logging.getLogger(__name__)
 
-class ActionCharmCharm(CharmBase):
+class ActionCharmCharm(ops.CharmBase):
     """Charm the service."""
 
     def __init__(self, *args):
@@ -43,4 +41,4 @@ class ActionCharmCharm(CharmBase):
             event.fail(message=e)
 
 if __name__ == "__main__":  # pragma: nocover
-    main(ActionCharmCharm)
+    ops.main(ActionCharmCharm)

--- a/corehooks-all/src/charm.py
+++ b/corehooks-all/src/charm.py
@@ -21,13 +21,9 @@
 import logging
 import os
 import shutil
-
-from ops.charm import CharmBase
-from ops.framework import StoredState
-from ops.main import main
-from ops.model import ActiveStatus, WaitingStatus, MaintenanceStatus
-import subprocess as sp
 import sys
+
+import ops
 
 logger = logging.getLogger(__name__)
 
@@ -38,10 +34,10 @@ EMOJI_RED_DOT = "\U0001F534"
 EMOJI_PACKAGE = "\U0001F4E6"
 
 
-class CorehooksAllCharm(CharmBase):
+class CorehooksAllCharm(ops.CharmBase):
     """Charm the hello service with all core hooks."""
 
-    _stored = StoredState()
+    _stored = ops.StoredState()
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -136,10 +132,10 @@ class CorehooksAllCharm(CharmBase):
 
         if not os.system('systemctl is-active hello.service') == 0:
             logger.info("hello service is not running.")
-            self.unit.status = MaintenanceStatus("Inactive.")
+            self.unit.status = ops.MaintenanceStatus("Inactive.")
         else:
             logger.info(f"hello service is running.")
-            self.unit.status = ActiveStatus("Running.")
+            self.unit.status = ops.ActiveStatus("Running.")
 
     def _on_upgrade_charm(self, event):
         logger.debug(EMOJI_CORE_HOOK_EVENT + sys._getframe().f_code.co_name)
@@ -192,4 +188,4 @@ class CorehooksAllCharm(CharmBase):
             os.system('systemctl restart hello.service')
 
 if __name__ == "__main__":
-    main(CorehooksAllCharm)
+    ops.main(CorehooksAllCharm)

--- a/deploy-minimal/src/charm.py
+++ b/deploy-minimal/src/charm.py
@@ -5,13 +5,12 @@
 # Learn more at: https://juju.is/docs/sdk
 
 import logging
-from ops.charm import CharmBase
-from ops.main import main
-from ops.model import MaintenanceStatus, ActiveStatus
+
+import ops
 
 logger = logging.getLogger(__name__)
 
-class DeployMinimalCharm(CharmBase):
+class DeployMinimalCharm(ops.CharmBase):
     """
         A minimalistic charm which only implements the deployment hooks
 
@@ -29,22 +28,22 @@ class DeployMinimalCharm(CharmBase):
             install is the first core hook to fire when deploying.
         """
         logger.info("Step 1/3: INSTALL")
-        self.unit.status = MaintenanceStatus("Step: 1/3")
+        self.unit.status = ops.MaintenanceStatus("Step: 1/3")
 
     def _on_config_changed(self, event):
         """
             config_changed is second core hook to fire when deploying.
         """
         logger.info("Step 2/3: CONFIG_CHANGED")
-        self.unit.status = MaintenanceStatus("Step: 2/3")
+        self.unit.status = ops.MaintenanceStatus("Step: 2/3")
 
     def _on_start(self, event):
         """
             start is the last core hook to fire when deploying.
         """
         logger.info("Step 3/3: START")
-        self.unit.status = ActiveStatus("Step: 3/3")
+        self.unit.status = ops.ActiveStatus("Step: 3/3")
 
 
 if __name__ == "__main__":
-    main(DeployMinimalCharm)
+    ops.main(DeployMinimalCharm)

--- a/deploy-with-storage/src/charm.py
+++ b/deploy-with-storage/src/charm.py
@@ -5,13 +5,12 @@
 # Learn more at: https://juju.is/docs/sdk
 
 import logging
-from ops.charm import CharmBase
-from ops.main import main
-from ops.model import MaintenanceStatus, ActiveStatus
+
+import ops
 
 logger = logging.getLogger(__name__)
 
-class DeployMinimalStorageCharm(CharmBase):
+class DeployMinimalStorageCharm(ops.CharmBase):
     """
     A charm which implements the deployment hooks including the storage hooks.
 
@@ -32,29 +31,29 @@ class DeployMinimalStorageCharm(CharmBase):
             storage with the name [foobar] defined in metadata.yaml
         """
         logger.info("Step 1/4: STORAGE_ATTACHED")
-        self.unit.status = MaintenanceStatus("Step: 1/4")
+        self.unit.status = ops.MaintenanceStatus("Step: 1/4")
 
     def _on_install(self, event):
         """
             install is the first core hook to fire when deploying.
         """
         logger.info("Step 2/4: INSTALL")
-        self.unit.status = MaintenanceStatus("Step: 2/4")
+        self.unit.status = ops.MaintenanceStatus("Step: 2/4")
 
     def _on_config_changed(self, event):
         """
             config_changed is second core hook to fire when deploying.
         """
         logger.info("Step 3/4: CONFIG_CHANGED")
-        self.unit.status = MaintenanceStatus("Step: 3/4")
+        self.unit.status = ops.MaintenanceStatus("Step: 3/4")
 
     def _on_start(self, event):
         """
             start is the last core hook to fire when deploying.
         """
         logger.info("Step 4/4: START")
-        self.unit.status = ActiveStatus("Step: 4/4")
+        self.unit.status = ops.ActiveStatus("Step: 4/4")
 
 
 if __name__ == "__main__":
-    main(DeployMinimalStorageCharm)
+    ops.main(DeployMinimalStorageCharm)

--- a/grafana-dashboard-example/src/charm.py
+++ b/grafana-dashboard-example/src/charm.py
@@ -2,22 +2,18 @@
 # Copyright 2021 Erik Lönroth
 # See LICENSE file for licensing details.
 
-import copy
 import os
 import logging
 import json
 import time
-from pathlib import Path
 import socket
-from typing import List
-from ops.charm import CharmBase, RelationChangedEvent, RelationDepartedEvent
-from ops.main import main
-from ops.model import ActiveStatus
+
+import ops
 
 
 logger = logging.getLogger(__name__)
 
-class GrafanaDashBoardCharm(CharmBase):
+class GrafanaDashBoardCharm(ops.CharmBase):
     """
     A charm that deploys a grafana dashboard to grafana.
     
@@ -44,7 +40,7 @@ class GrafanaDashBoardCharm(CharmBase):
         self.framework.observe(self.on.scrape_relation_changed, 
                                 self._on_scrape_relation_changed)
         
-    def _install(self,event):
+    def _install(self, event):
         """
         Install prometheus-node-exporter so to provide some metrics.
         """
@@ -53,7 +49,7 @@ class GrafanaDashBoardCharm(CharmBase):
         
 
 
-    def _on_grafana_dashboard_relation_changed(self, event: RelationChangedEvent) -> None:
+    def _on_grafana_dashboard_relation_changed(self, event: ops.RelationChangedEvent) -> None:
         """Provide the dashboard to Grafana."""
         # Only one dashboard is needed so let the app leader deal with it
         if not self.unit.is_leader():
@@ -146,7 +142,7 @@ class GrafanaDashBoardCharm(CharmBase):
         )
         logger.debug("Dashboard sent to Grafana")
 
-    def _on_scrape_relation_changed(self, event: RelationChangedEvent) -> None:
+    def _on_scrape_relation_changed(self, event: ops.RelationChangedEvent) -> None:
         """
         Provide basic node exporter metrics
         """
@@ -161,4 +157,4 @@ class GrafanaDashBoardCharm(CharmBase):
 
 
 if __name__ == "__main__":
-    main(GrafanaDashBoardCharm)
+    ops.main(GrafanaDashBoardCharm)

--- a/haproxy-relate/src/charm.py
+++ b/haproxy-relate/src/charm.py
@@ -5,15 +5,14 @@
 import os
 import logging
 import socket
-from ops.charm import CharmBase
-from ops.main import main
-from ops.model import ActiveStatus, MaintenanceStatus
+
+import ops
 import yaml
 from jinja2 import Environment
 
 logger = logging.getLogger(__name__)
 
-class HaproyRelate(CharmBase):
+class HaproyRelate(ops.CharmBase):
     """
     Relate to haproxy, using service directive as:
 
@@ -44,7 +43,7 @@ class HaproyRelate(CharmBase):
     def _on_install(self,event):
         """ Install """
         
-        self.unit.status = MaintenanceStatus("installing microsample snap")
+        self.unit.status = ops.MaintenanceStatus("installing microsample snap")
         os.system('snap install microsample --edge')
 
         
@@ -56,7 +55,7 @@ class HaproyRelate(CharmBase):
         event.relation.data[self.model.unit]['services'] = self._render_services()
 
         # Set active status
-        self.unit.status = ActiveStatus("Ready, relation data sent.")
+        self.unit.status = ops.ActiveStatus("Ready, relation data sent.")
 
     def _render_services(self):
         """
@@ -95,4 +94,4 @@ class HaproyRelate(CharmBase):
 
         
 if __name__ == "__main__":
-    main(HaproyRelate)
+    ops.main(HaproyRelate)

--- a/lxd-profile/src/charm.py
+++ b/lxd-profile/src/charm.py
@@ -5,13 +5,12 @@
 # Learn more at: https://juju.is/docs/sdk
 
 import logging
-from ops.charm import CharmBase
-from ops.main import main
-from ops.model import MaintenanceStatus, ActiveStatus
+
+import ops
 
 logger = logging.getLogger(__name__)
 
-class LxdProfileCharm(CharmBase):
+class LxdProfileCharm(ops.CharmBase):
     """
         This charm demonstrate use of lxd-profile.yaml
         Note that you need to change the charm file for this to take effect.
@@ -27,8 +26,8 @@ class LxdProfileCharm(CharmBase):
             The lxd-profile.yaml gets updated as part of a upgrade-charm event.
         """
         logger.info("LXD profile is updated!")
-        self.unit.status = ActiveStatus("LXD profile was updated.")
+        self.unit.status = ops.ActiveStatus("LXD profile was updated.")
 
 
 if __name__ == "__main__":
-    main(LxdProfileCharm)
+    ops.main(LxdProfileCharm)

--- a/metrics-base/src/charm.py
+++ b/metrics-base/src/charm.py
@@ -7,22 +7,16 @@
 
 import logging
 
-from ops.charm import CharmBase
-from ops.framework import StoredState
-from ops.main import main
-from ops.model import ActiveStatus
-import subprocess as sp
-import sys
-import subprocess
+import ops
 import psutil
 
 logger = logging.getLogger(__name__)
 
 EMOJI_CORE_HOOK_EVENT = "\U0001F4CC"
 
-class MetricsBaseCharm(CharmBase):
+class MetricsBaseCharm(ops.CharmBase):
 
-    _stored = StoredState()
+    _stored = ops.StoredState()
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -54,4 +48,4 @@ class MetricsBaseCharm(CharmBase):
         event.add_metrics({"mem_used": mem_used, "load_5": load_5})
 
 if __name__ == "__main__":
-    main(MetricsBaseCharm)
+    ops.main(MetricsBaseCharm)

--- a/monitoring-nrpe/src/charm.py
+++ b/monitoring-nrpe/src/charm.py
@@ -3,15 +3,14 @@
 # See LICENSE file for licensing details.
 
 import os
-from ops.charm import CharmBase
-from ops.main import main
-from ops.model import ActiveStatus
+
+import ops
 from charmhelpers.contrib.charmsupport.nrpe import NRPE
 from charmhelpers.core import hookenv, host
 
 NAGIOS_PLUGINS_DIR = "/usr/local/lib/nagios/plugins/"
 
-class MonitoringNrpeCharm(CharmBase):
+class MonitoringNrpeCharm(ops.CharmBase):
     """
     A charm that deploys a monitoring script and allows to be
     related to nrpe:local-monitors to be used with nagios.
@@ -43,7 +42,7 @@ class MonitoringNrpeCharm(CharmBase):
         self.restart_nrpe_service()
 
         # Set active status
-        self.unit.status = ActiveStatus("Monitoring")
+        self.unit.status = ops.ActiveStatus("Monitoring")
 
 
     @property
@@ -78,4 +77,4 @@ class MonitoringNrpeCharm(CharmBase):
         
     
 if __name__ == "__main__":
-    main(MonitoringNrpeCharm)
+    ops.main(MonitoringNrpeCharm)

--- a/observed/src/charm.py
+++ b/observed/src/charm.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python3
 
-from charms.grafana_agent.v0.cos_agent import COSAgentProvider
-from ops.charm import CharmBase
-from ops.main import main
-from ops.model import ActiveStatus, MaintenanceStatus
 import os
 import subprocess as sp
 
+import ops
+from charms.grafana_agent.v0.cos_agent import COSAgentProvider
+
 EMOJI_GREEN_DOT = "\U0001F7E2"
 
-class ObservedCharm(CharmBase):
+class ObservedCharm(ops.CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -38,9 +37,9 @@ class ObservedCharm(CharmBase):
     def _on_install(self, theevent):
         # Install from configured channel
         channel = self.config.get('channel')
-        self.unit.status = MaintenanceStatus("Installing microsample snap")
+        self.unit.status = ops.MaintenanceStatus("Installing microsample snap")
         os.system(f"snap install microsample --{channel}")
-        self.unit.status = ActiveStatus(EMOJI_GREEN_DOT + " Ready")
+        self.unit.status = ops.ActiveStatus(EMOJI_GREEN_DOT + " Ready")
 
 
     def _on_config_changed(self, theevent):
@@ -66,8 +65,8 @@ class ObservedCharm(CharmBase):
         self.unit.set_workload_version("1.0")
         
         # Set active status.
-        self.unit.status = ActiveStatus(EMOJI_GREEN_DOT + " Ready")
+        self.unit.status = ops.ActiveStatus(EMOJI_GREEN_DOT + " Ready")
 
 
 if __name__ == "__main__":
-    main(ObservedCharm)
+    ops.main(ObservedCharm)

--- a/storage-filesystem/src/charm.py
+++ b/storage-filesystem/src/charm.py
@@ -12,10 +12,8 @@ import logging
 import os
 import shutil
 import functools
-from ops.charm import CharmBase
-from ops.main import main
-from ops.model import ActiveStatus
-import sys
+
+import ops
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +38,7 @@ def logdecorate(prefix):
     return decorate
 
 
-class StorageFilesystemCharm(CharmBase):
+class StorageFilesystemCharm(ops.CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -94,8 +92,8 @@ class StorageFilesystemCharm(CharmBase):
         """
         os.system('systemctl disable var-log-mylogs.mount --now')
         os.remove('/etc/systemd/system/var-log-mylogs.mount')
-        self.unit.status = ActiveStatus(f"{EMOJI_CROSS_MARK_BUTTON} Detached storage.")
+        self.unit.status = ops.ActiveStatus(f"{EMOJI_CROSS_MARK_BUTTON} Detached storage.")
 
         
 if __name__ == "__main__":
-    main(StorageFilesystemCharm)
+    ops.main(StorageFilesystemCharm)


### PR DESCRIPTION
As part of [canonical/operator#921](https://github.com/canonical/operator/issues/921), we're updating the docs to use the now-recommended "import ops" style, that is, instead of:

```python
from ops.charm import CharmBase
from ops.main import main
class MyC(CharmBase):
    ...
if __name__ == "__main__":
    main(MyC)
```

We prefer people do:

```python
import ops
class MyC(ops.CharmBase):
    ...
if __name__ == "__main__":
    ops.main(MyC)
```

This PR updates all of the charm.py files to use this style. Since these are referred to from the machine charm tutorial, it would be ideal if they matched the preferred style, so that it's what new charmers are exposed to.

A few unused imports are also removed.